### PR TITLE
Remove call to `env.js` and provide the endpoint URL in the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ TADO_DATA=/path/to/data
 TADO_DEFAULT_SCHEDULE="Winter Schedule"
 ```
 
-There is also an optional `TADO_ENV` that has a default value of `https://my.tado.com/webapp/env.js`
+There is also an optional `TADO_API_ENDPOINT` that has a default value of `https://my.tado.com/api/v2`
 and a `TADO_OAUTH2_ENDPOINT` that has a default value of `https://login.tado.com/oauth2`.
 
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     api_key: str
     tado_data: str
     tado_default_schedule: str
-    tado_env: Optional[str] = None
+    tado_api_endpoint: Optional[str] = None
     tado_oauth2_endpoint: Optional[str] = None
 
     model_config = SettingsConfigDict(env_file=".env")
@@ -48,7 +48,7 @@ def get_client():
     settings = get_settings()
     client = TadoClient(
         data=settings.tado_data,
-        env=settings.tado_env,
+        api_endpoint=settings.tado_api_endpoint,
         oauth2_endpoint=settings.tado_oauth2_endpoint,
         logger=logger,
     )

--- a/tests/app/mock_env.js
+++ b/tests/app/mock_env.js
@@ -1,6 +1,0 @@
-var TD = {
-	config: {
-		tgaRestApiEndpoint: 'http://localhost:8081/api/v1',
-		tgaRestApiV2Endpoint: 'http://localhost:8081/api/v2'
-	}
-};

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,30 +8,16 @@ from smart.schedule import Schedule
 from smart.tado import TadoClient
 
 
-class EnvResponse:
-    def __init__(self, text):
-        self.text = text
-
-
 @pytest.fixture
 def tado_client():
     return create_tado_client()
 
 
 def create_tado_client():
-    env = "http://localhost:8080/webapp/env.js"
-
-    def get_env(url):
-        assert url == env
-        with (Path(__file__).parent / "mock_env.txt").open() as fp:
-            text = fp.read().strip()
-        return EnvResponse(text=text)
-
     requests_session = Mock()
-    requests_session.get.side_effect = get_env
     client = TadoClient(
         data=".",
-        env=env,
+        api_endpoint="http://localhost:8080/api/v2",
         oauth2_endpoint="http://localhost:8080/oauth2",
         requests_session=requests_session,
     )

--- a/tests/mock_env.txt
+++ b/tests/mock_env.txt
@@ -1,6 +1,0 @@
-var TD = {
-	config: {
-		tgaRestApiEndpoint: 'http://localhost:8080/api/v1',
-		tgaRestApiV2Endpoint: 'http://localhost:8080/api/v2'
-	}
-};


### PR DESCRIPTION
`env.js` is no longer accessible, however we can just hardcode the API endpoint in the code (with the option to customise it via env var or Python API). This should only be a breaking change if you are specifying `TADO_ENV` or passing a custom value to the `Tado` class directly.

Also upgrades the `me` endpoint to the v2 API.